### PR TITLE
add encoding_format parameter for better defaults.

### DIFF
--- a/src/ingest/embeddings.ts
+++ b/src/ingest/embeddings.ts
@@ -70,6 +70,7 @@ export class OpenAIEmbedder implements Embedder {
           body: JSON.stringify({
             model: this.model,
             input: texts,
+            encoding_format: float
           }),
         });
 


### PR DESCRIPTION
Some models although marked as optional expect this parameter to be available and fail embedding otherwise